### PR TITLE
Hide utility markdown tabs from homepage navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,7 @@ plugins:
   - jekyll-remote-theme
 
 google_analytics: G-HYN8MF0VM4
+
+# Keep header navigation explicit so utility docs don't appear as tabs.
+header_pages:
+  - contact.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- configured explicit `header_pages` in Jekyll config
- kept only `contact.md` in the header navigation list
- this hides utility markdown files (including `AGENTS.md` and `cursor-agent-chat-log.md`) from homepage tabs without deleting those files

## Testing
- configuration-only change; verified diff in `_config.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7695d2a-a622-45a1-ad04-af667824613c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7695d2a-a622-45a1-ad04-af667824613c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

