### PR TITLE
Set up dev environment: add webrick + Cloud setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,14 @@ graph TD
 - 涉及大量替换（如全文统一大小写、引号风格切换、拼音→原词、**的/地/得**），用 Python 脚本一次性处理整个 body，比逐处 `StrReplace` 更可靠；YAML front matter 要单独保留。
 - 共用逻辑在 `scripts/post_format.py`（`split_front_matter`、`fix_body`、`fix_de_di_dei`、`audit` 等）；各篇故事的 `scripts/fix_*.py` 只放本篇专有替换，通过 `extra_replacements` 等参数传入。
 - 完成后用 `audit()` 或 Python 数一下剩余的 ASCII `"`、目标缩写出现次数，确认替换干净。
+
+## Cursor Cloud specific instructions
+
+这是一个 Jekyll 3.8 静态站点（Ruby 3.2）。依赖已由启动更新脚本安装到 `vendor/bundle`（`bundle install`）。以下为运行时的非显然注意事项：
+
+- **本地预览用 `--no-watch`**：`bundle exec jekyll serve --no-watch --host 0.0.0.0 --port 4000 --config _config.yml,_config.local-preview.yml`。默认的 `--watch`（自动重建）在 Ruby 3.2 下会崩溃（`pathutil` 读取 `/proc/version` 触发 `no implicit conversion of Hash into Integer`）。所以改动 `_posts/` 后需手动重跑 `jekyll build` 或重启 serve 才能看到更新，没有热重载。
+- **构建即校验**：`bundle exec jekyll build --config _config.yml,_config.local-preview.yml` 会渲染全部 `_posts/`，是本仓库事实上的 lint/test；构建通过即视为通过。仓库没有单独的测试套件。`jekyll doctor` 在此旧版本 + 新 `addressable` 下会报错，勿用。
+- **`_config.local-preview.yml`**：本地预览需叠加此配置（`_config.yml,_config.local-preview.yml`），它会排除 `vendor/` 和一篇有问题的草稿目录，避免构建报错。
+- **`remote_theme`**：主题 `jekyll/minima` 在构建时从 GitHub 拉取，需要网络；离线环境会构建失败。
+- **`webrick`**：已加入 `Gemfile`（Ruby 3.0+ 移除了默认 webrick，而 Jekyll 3.x 的 `serve` 仍依赖它）。
+- `Gemfile.lock`、`_site/`、`vendor/` 均被 `.gitignore` 忽略，不要提交。

--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,7 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem 'rexml'
 
 gem 'jekyll-remote-theme'
+
+# WEBrick was removed from Ruby's default gems in Ruby 3.0+, but Jekyll 3.x's
+# built-in server (`jekyll serve`) still requires it.
+gem 'webrick', '~> 1.8'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Jekyll (Ruby 3.2) Chinese story archive and documents how to run it.

### Changes
- **`Gemfile`**: add `webrick` gem. Ruby 3.0+ removed WEBrick from default gems, but Jekyll 3.8's built-in server (`jekyll serve`) still requires it.
- **`AGENTS.md`**: add a `## Cursor Cloud specific instructions` section with durable, non-obvious run caveats (see below).

### Environment
- Installed system deps: `ruby-full` (3.2.3), `build-essential`, `libssl-dev`, `libffi-dev`, `libyaml-dev` (needed for native gems like `openssl`).
- Gems install to `vendor/bundle` via `bundle install` (git-ignored).

### Verified
- `bundle exec jekyll build --config _config.yml,_config.local-preview.yml` → builds cleanly (renders all `_posts/`; this is the effective lint/test).
- `bundle exec jekyll serve --no-watch --host 0.0.0.0 --port 4000 --config _config.yml,_config.local-preview.yml` → serves at HTTP 200.
- Browser walkthrough: homepage renders the post list; clicking a story opens its post page with fully rendered Chinese content.

### Key caveats (also in AGENTS.md)
- Use `--no-watch`: the default `--watch` crashes on Ruby 3.2 (`pathutil` reading `/proc/version`). No hot reload — rebuild/restart to see changes.
- `remote_theme` (`jekyll/minima`) is fetched from GitHub at build time (needs network).
- `jekyll doctor` is broken with this old Jekyll + newer `addressable`; don't use it.

[jekyll_site_browse_walkthrough.mp4](https://cursor.com/agents/bc-9bc30746-9afa-43d8-89f3-988fdaefa87f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjekyll_site_browse_walkthrough.mp4)

[Homepage post list](https://cursor.com/agents/bc-9bc30746-9afa-43d8-89f3-988fdaefa87f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_post_list.webp)
[Story post page](https://cursor.com/agents/bc-9bc30746-9afa-43d8-89f3-988fdaefa87f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_post_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bc30746-9afa-43d8-89f3-988fdaefa87f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bc30746-9afa-43d8-89f3-988fdaefa87f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

